### PR TITLE
- You should rename the weight column to atomic_mass

### DIFF
--- a/periodic-table/periodic_table.sql
+++ b/periodic-table/periodic_table.sql
@@ -49,8 +49,8 @@ SET default_table_access_method = heap;
 
 CREATE TABLE public.elements (
     atomic_number integer NOT NULL,
-    symbol character varying(2),
-    name character varying(40)
+    symbol character varying(2) NOT NULL,
+    name character varying(40) NOT NULL
 );
 
 
@@ -63,9 +63,9 @@ ALTER TABLE public.elements OWNER TO freecodecamp;
 CREATE TABLE public.properties (
     atomic_number integer NOT NULL,
     type character varying(30),
-    weight numeric(9,6) NOT NULL,
-    melting_point numeric,
-    boiling_point numeric
+    atomic_mass numeric(9,6) NOT NULL,
+    melting_point_celsius numeric NOT NULL,
+    boiling_point_celsius numeric NOT NULL
 );
 
 
@@ -118,6 +118,14 @@ ALTER TABLE ONLY public.elements
 
 
 --
+-- Name: elements name_unique; Type: CONSTRAINT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.elements
+    ADD CONSTRAINT name_unique UNIQUE (name);
+
+
+--
 -- Name: properties properties_atomic_number_key; Type: CONSTRAINT; Schema: public; Owner: freecodecamp
 --
 
@@ -131,6 +139,22 @@ ALTER TABLE ONLY public.properties
 
 ALTER TABLE ONLY public.properties
     ADD CONSTRAINT properties_pkey PRIMARY KEY (atomic_number);
+
+
+--
+-- Name: elements symbol_unique; Type: CONSTRAINT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.elements
+    ADD CONSTRAINT symbol_unique UNIQUE (symbol);
+
+
+--
+-- Name: properties properties_atomic_number_fkey; Type: FK CONSTRAINT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.properties
+    ADD CONSTRAINT properties_atomic_number_fkey FOREIGN KEY (atomic_number) REFERENCES public.elements(atomic_number);
 
 
 --


### PR DESCRIPTION
- You should rename the melting_point column to melting_point_celsius and the boiling_point column to boiling_point_celsius
- Your melting_point_celsius and boiling_point_celsius columns should not accept null values
- You should add the UNIQUE constraint to the symbol and name columns from the elements table
- Your symbol and name columns should have the NOT NULL constraint
- You should set the atomic_number column from the properties table as a foreign key that references the column of the same name in the elements table