### PR TITLE
- You should create a types table that will store the three types of …

### DIFF
--- a/periodic-table/periodic_table.sql
+++ b/periodic-table/periodic_table.sql
@@ -65,11 +65,53 @@ CREATE TABLE public.properties (
     type character varying(30),
     atomic_mass numeric(9,6) NOT NULL,
     melting_point_celsius numeric NOT NULL,
-    boiling_point_celsius numeric NOT NULL
+    boiling_point_celsius numeric NOT NULL,
+    type_id integer NOT NULL
 );
 
 
 ALTER TABLE public.properties OWNER TO freecodecamp;
+
+--
+-- Name: types; Type: TABLE; Schema: public; Owner: freecodecamp
+--
+
+CREATE TABLE public.types (
+    type character varying(30) NOT NULL,
+    type_id integer NOT NULL
+);
+
+
+ALTER TABLE public.types OWNER TO freecodecamp;
+
+--
+-- Name: types_type_id_seq; Type: SEQUENCE; Schema: public; Owner: freecodecamp
+--
+
+CREATE SEQUENCE public.types_type_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.types_type_id_seq OWNER TO freecodecamp;
+
+--
+-- Name: types_type_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: freecodecamp
+--
+
+ALTER SEQUENCE public.types_type_id_seq OWNED BY public.types.type_id;
+
+
+--
+-- Name: types type_id; Type: DEFAULT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.types ALTER COLUMN type_id SET DEFAULT nextval('public.types_type_id_seq'::regclass);
+
 
 --
 -- Data for Name: elements; Type: TABLE DATA; Schema: public; Owner: freecodecamp
@@ -90,15 +132,31 @@ INSERT INTO public.elements VALUES (1000, 'mT', 'moTanium');
 -- Data for Name: properties; Type: TABLE DATA; Schema: public; Owner: freecodecamp
 --
 
-INSERT INTO public.properties VALUES (1, 'nonmetal', 1.008000, -259.1, -252.9);
-INSERT INTO public.properties VALUES (2, 'nonmetal', 4.002600, -272.2, -269);
-INSERT INTO public.properties VALUES (3, 'metal', 6.940000, 180.54, 1342);
-INSERT INTO public.properties VALUES (4, 'metal', 9.012200, 1287, 2470);
-INSERT INTO public.properties VALUES (5, 'metalloid', 10.810000, 2075, 4000);
-INSERT INTO public.properties VALUES (6, 'nonmetal', 12.011000, 3550, 4027);
-INSERT INTO public.properties VALUES (7, 'nonmetal', 14.007000, -210.1, -195.8);
-INSERT INTO public.properties VALUES (8, 'nonmetal', 15.999000, -218, -183);
-INSERT INTO public.properties VALUES (1000, 'metalloid', 1.000000, 10, 100);
+INSERT INTO public.properties VALUES (8, 'nonmetal', 15.999000, -218, -183, 1);
+INSERT INTO public.properties VALUES (7, 'nonmetal', 14.007000, -210.1, -195.8, 1);
+INSERT INTO public.properties VALUES (6, 'nonmetal', 12.011000, 3550, 4027, 1);
+INSERT INTO public.properties VALUES (2, 'nonmetal', 4.002600, -272.2, -269, 1);
+INSERT INTO public.properties VALUES (1, 'nonmetal', 1.008000, -259.1, -252.9, 1);
+INSERT INTO public.properties VALUES (4, 'metal', 9.012200, 1287, 2470, 2);
+INSERT INTO public.properties VALUES (3, 'metal', 6.940000, 180.54, 1342, 2);
+INSERT INTO public.properties VALUES (1000, 'metalloid', 1.000000, 10, 100, 3);
+INSERT INTO public.properties VALUES (5, 'metalloid', 10.810000, 2075, 4000, 3);
+
+
+--
+-- Data for Name: types; Type: TABLE DATA; Schema: public; Owner: freecodecamp
+--
+
+INSERT INTO public.types VALUES ('nonmetal', 1);
+INSERT INTO public.types VALUES ('metal', 2);
+INSERT INTO public.types VALUES ('metalloid', 3);
+
+
+--
+-- Name: types_type_id_seq; Type: SEQUENCE SET; Schema: public; Owner: freecodecamp
+--
+
+SELECT pg_catalog.setval('public.types_type_id_seq', 3, true);
 
 
 --
@@ -150,11 +208,27 @@ ALTER TABLE ONLY public.elements
 
 
 --
+-- Name: types types_pkey; Type: CONSTRAINT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.types
+    ADD CONSTRAINT types_pkey PRIMARY KEY (type_id);
+
+
+--
 -- Name: properties properties_atomic_number_fkey; Type: FK CONSTRAINT; Schema: public; Owner: freecodecamp
 --
 
 ALTER TABLE ONLY public.properties
     ADD CONSTRAINT properties_atomic_number_fkey FOREIGN KEY (atomic_number) REFERENCES public.elements(atomic_number);
+
+
+--
+-- Name: properties properties_type_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: freecodecamp
+--
+
+ALTER TABLE ONLY public.properties
+    ADD CONSTRAINT properties_type_id_fkey FOREIGN KEY (type_id) REFERENCES public.types(type_id);
 
 
 --


### PR DESCRIPTION
…elements

- Your types table should have a type_id column that is an integer and the primary key
- Your types table should have a type column that's a VARCHAR and cannot be null. It will store the different types from the type column in the properties table
- You should add three rows to your types table whose values are the three different types from the properties table
- Your properties table should have a type_id foreign key column that references the type_id column from the types table. It should be an INT with the NOT NULL constraint
- Each row in your properties table should have a type_id value that links to the correct type from the types table