### PR TITLE
- If the argument input to your element.sh script doesn't exist as an…

### DIFF
--- a/periodic-table/element.sh
+++ b/periodic-table/element.sh
@@ -20,7 +20,7 @@ else
     # reading data
     echo "$ELEMENT_SELECTED" | while IFS="|" read A_NUMBER NAME SYMBOL TYPE A_MASS M_POINT B_POINT
     do
-      echo -e "The element with atomic number $A_NUMBER is $NAME ($SYMBOL). It's a $TYPE, with a mass of $A_MASS amu. Hydrogen has a melting point of $M_POINT celsius and a boiling point of $B_POINT celsius."
+      echo -e "The element with atomic number $A_NUMBER is $NAME ($SYMBOL). It's a $TYPE, with a mass of $A_MASS amu. $NAME has a melting point of $M_POINT celsius and a boiling point of $B_POINT celsius."
     done
   fi
 

--- a/periodic-table/periodic_table.sql
+++ b/periodic-table/periodic_table.sql
@@ -62,7 +62,6 @@ ALTER TABLE public.elements OWNER TO freecodecamp;
 
 CREATE TABLE public.properties (
     atomic_number integer NOT NULL,
-    type character varying(30),
     atomic_mass numeric NOT NULL,
     melting_point_celsius numeric NOT NULL,
     boiling_point_celsius numeric NOT NULL,
@@ -125,7 +124,6 @@ INSERT INTO public.elements VALUES (5, 'B', 'Boron');
 INSERT INTO public.elements VALUES (6, 'C', 'Carbon');
 INSERT INTO public.elements VALUES (7, 'N', 'Nitrogen');
 INSERT INTO public.elements VALUES (8, 'O', 'Oxygen');
-INSERT INTO public.elements VALUES (1000, 'MT', 'moTanium');
 INSERT INTO public.elements VALUES (9, 'F', 'Fluorine');
 INSERT INTO public.elements VALUES (10, 'Ne', 'Neon');
 
@@ -134,17 +132,16 @@ INSERT INTO public.elements VALUES (10, 'Ne', 'Neon');
 -- Data for Name: properties; Type: TABLE DATA; Schema: public; Owner: freecodecamp
 --
 
-INSERT INTO public.properties VALUES (8, 'nonmetal', 15.999, -218, -183, 1);
-INSERT INTO public.properties VALUES (7, 'nonmetal', 14.007, -210.1, -195.8, 1);
-INSERT INTO public.properties VALUES (6, 'nonmetal', 12.011, 3550, 4027, 1);
-INSERT INTO public.properties VALUES (2, 'nonmetal', 4.0026, -272.2, -269, 1);
-INSERT INTO public.properties VALUES (1, 'nonmetal', 1.008, -259.1, -252.9, 1);
-INSERT INTO public.properties VALUES (4, 'metal', 9.0122, 1287, 2470, 2);
-INSERT INTO public.properties VALUES (3, 'metal', 6.94, 180.54, 1342, 2);
-INSERT INTO public.properties VALUES (1000, 'metalloid', 1, 10, 100, 3);
-INSERT INTO public.properties VALUES (5, 'metalloid', 10.81, 2075, 4000, 3);
-INSERT INTO public.properties VALUES (9, 'nonmetal', 18.998, -220, -188.1, 1);
-INSERT INTO public.properties VALUES (10, 'nonmetal', 20.18, -248.6, -246.1, 1);
+INSERT INTO public.properties VALUES (8, 15.999, -218, -183, 1);
+INSERT INTO public.properties VALUES (7, 14.007, -210.1, -195.8, 1);
+INSERT INTO public.properties VALUES (6, 12.011, 3550, 4027, 1);
+INSERT INTO public.properties VALUES (2, 4.0026, -272.2, -269, 1);
+INSERT INTO public.properties VALUES (1, 1.008, -259.1, -252.9, 1);
+INSERT INTO public.properties VALUES (4, 9.0122, 1287, 2470, 2);
+INSERT INTO public.properties VALUES (3, 6.94, 180.54, 1342, 2);
+INSERT INTO public.properties VALUES (5, 10.81, 2075, 4000, 3);
+INSERT INTO public.properties VALUES (9, 18.998, -220, -188.1, 1);
+INSERT INTO public.properties VALUES (10, 20.18, -248.6, -246.1, 1);
 
 
 --


### PR DESCRIPTION
… atomic_number, symbol, or name in the database, the only output should be I could not find that element in the database.

- If you run ./element.sh script with another element as input, you should get the same output but with information associated with the given element.
- You should delete the non existent element, whose atomic_number is 1000, from the two tables
- Your properties table should not have a type column